### PR TITLE
Enable OS X builds on travis

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -28,5 +28,6 @@ inst/manual/docstring_templates.txt
 Makevars^
 appveyor.yml
 .travis.yml
+.travis_setup.sh
 ^.*\.Rproj$
 ^\.Rproj\.user$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,36 @@
 language: r
 sudo: true
 cache: packages
+os:
+  - linux
+  - osx
 dist: trusty
+  
 env:
   global:
-  - PKG_CFLAGS="-pedantic"
-  - _R_CHECK_CRAN_INCOMING_=FALSE
-  - ASAN="-fsanitize=address -fno-omit-frame-pointer"
-  - HDF5_RELEASE_URL="https://support.hdfgroup.org/ftp/HDF5/releases"
+    - PKG_CFLAGS="-pedantic"
+    - _R_CHECK_CRAN_INCOMING_=FALSE
+    - ASAN="-fsanitize=address -fno-omit-frame-pointer"
+    - HDF5_RELEASE_URL="https://support.hdfgroup.org/ftp/HDF5/releases"
   matrix:
-  - HDF5_VERSION=1.8.12
-  - HDF5_VERSION=1.8.13
-  - HDF5_VERSION=1.8.14
-  - HDF5_VERSION=1.8.15-patch1
-  - HDF5_VERSION=1.8.16
-  - HDF5_VERSION=1.8.17
-  - HDF5_VERSION=1.10.0-patch1
+    - HDF5_VERSION=1.8.12
+    #- HDF5_VERSION=1.8.13
+    - HDF5_VERSION=1.8.14
+    #- HDF5_VERSION=1.8.15-patch1
+    - HDF5_VERSION=1.8.16
+    #- HDF5_VERSION=1.8.17
+    - HDF5_VERSION=1.10.0-patch1
+
+matrix:
+  exclude:
+    - os: osx
+  include:
+    - os: osx
+      env: HDF5_VERSION=1.8.16
+  allow_failures:
+    - os: osx
+  fast_finish: true
+  
 warnings_are_errors: true
 addons:
   apt:
@@ -25,17 +40,10 @@ addons:
       - build-essential
       - libtool
       - libmagick++-dev
-before_install:
-- cd ..
-- if [ "$HDF5_VERSION" == "1.10.0-patch1" ]; 
-  then wget "$HDF5_RELEASE_URL/hdf5-1.10/hdf5-1.10.0-patch1/src/hdf5-1.10.0-patch1.tar.gz"; else 
-  wget "$HDF5_RELEASE_URL/hdf5-$HDF5_VERSION/src/hdf5-$HDF5_VERSION.tar.gz";
-  fi
-- tar -xzf "hdf5-$HDF5_VERSION.tar.gz"
-- cd "hdf5-$HDF5_VERSION"
-- ./configure --prefix=/usr/local
-- sudo make install
-- cd ../hdf5r
+      
+before_install: 
+  - chmod +x travis_setup.sh
+  - ./travis_setup.sh
 
 r_github_packages:
 - jimhester/covr
@@ -46,4 +54,5 @@ after_success:
 notifications:
   email:
     - mario.annau@gmail.com
+    - hhoeflin@gmail.com
 

--- a/travis_setup.sh
+++ b/travis_setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then # use homebrew version
+  brew install homebrew/science/hdf5
+else # install from source
+  cd ..
+  if [ "$HDF5_VERSION" == "1.10.0-patch1" ]; then
+    wget "$HDF5_RELEASE_URL/hdf5-1.10/hdf5-1.10.0-patch1/src/hdf5-1.10.0-patch1.tar.gz"
+  else
+    wget "$HDF5_RELEASE_URL/hdf5-$HDF5_VERSION/src/hdf5-$HDF5_VERSION.tar.gz"
+  fi
+  tar -xzf "hdf5-$HDF5_VERSION.tar.gz"
+  cd "hdf5-$HDF5_VERSION"
+  ./configure --prefix=/usr/local
+  sudo make install
+  cd ../hdf5r
+fi


### PR DESCRIPTION
Finally the build matrix with OSX should work. Just a few addtional Notes:

1. ```allow_failures``` is enabled for OSX builds since travis build otherwise take a very long time. This also means that OSX builds need to be checked manually (no extra badge available?)
2. Build time could be further reduced by limiting the matrix to only 4-5 elements (8min vs 16min). Maybe we could think of dropping 2-3 versions without risking failures for specific versions.
3. One test case seems to fail on OSX and needs to be fixed.