### PR TITLE
Fixed all issues of tests on windows

### DIFF
--- a/R/Common_functions.R
+++ b/R/Common_functions.R
@@ -93,7 +93,7 @@ commonFG <- list(
         "\\url{https://www.hdfgroup.org/HDF5/doc/RM/RM_H5D.html#Dataset-Open} for datasets, "
         "\\url{https://www.hdfgroup.org/HDF5/doc/RM/RM_H5O.html#Object-Open} for types and "
         "\\url{https://www.hdfgroup.org/HDF5/doc/RM/RM_H5O.html#Object-Open} for general objects."
-        
+
         if (length(name)!=1 || !is.character(name)) stop("'name' must be a character string of length 1")
 
         ## check the property lists and get their ids if they aren't already default
@@ -110,7 +110,7 @@ commonFG <- list(
             else if(type_access_pl$id != h5const$H5P_DEFAULT$id) {
                 oid <- .Call("R_H5Topen2", self$id, name, type_access_pl$id, PACKAGE = "hdf5r")$return_val
             }
-            else {            
+            else {
                 oid <- .Call("R_H5Oopen", self$id, name, link_access_pl$id, PACKAGE = "hdf5r")$return_val
             }
             if(oid < 0) {
@@ -146,7 +146,7 @@ commonFG <- list(
     ls=function(recursive=FALSE, detailed=FALSE, index_type=h5const$H5_INDEX_NAME, order=h5const$H5_ITER_NATIVE, link_access_pl=h5const$H5P_DEFAULT,
         dataset_access_pl=h5const$H5P_DEFAULT, type_access_pl=h5const$H5P_DEFAULT) {
         "Returns the contents of a file or group as a data.frame."
-        
+
         ls_res <- .Call("R_H5ls", self$id, recursive, index_type, order, link_access_pl$id,
                         dataset_access_pl$id, type_access_pl$id, PACKAGE='hdf5r')$return_val
         ls_res <- clean_ls_df(ls_res)
@@ -206,7 +206,7 @@ commonFG <- list(
         }
         check_pl(link_create_pl, "H5P_LINK_CREATE")
         check_pl(object_copy_pl, "H5P_OBJECT_COPY")
-        
+
         herr <- .Call("R_H5Ocopy", self$id, src_name, dst_loc$id, dst_name, object_copy_pl$id, link_create_pl$id, PACKAGE = "hdf5r")$return_val
         if(herr < 0) {
             stop("Error copying object")
@@ -222,7 +222,7 @@ commonFG <- list(
         }
         check_pl(link_create_pl, "H5P_LINK_CREATE")
         check_pl(object_copy_pl, "H5P_OBJECT_COPY")
-        
+
         herr <- .Call("R_H5Ocopy", src_loc$id, src_name, self$id, dst_name, object_copy_pl$id, link_create_pl$id, PACKAGE = "hdf5r")$return_val
         if(herr < 0) {
             stop("Error copying object")
@@ -240,7 +240,7 @@ commonFG <- list(
         if(res$return_val < 0) {
             stop("Could not retrieve object info by index")
         }
-        
+
         if(remove_internal_use_only) {
             oinfo <- res$oinfo
             oinfo$meta_size <- NULL
@@ -319,11 +319,11 @@ commonFG <- list(
         if(length(name) > 1) {
             stop("name has to be of length at most 1")
         }
-        
+
         check_pl(link_create_pl, "H5P_LINK_CREATE")
         check_pl(group_create_pl, "H5P_GROUP_CREATE")
         check_pl(group_access_pl, "H5P_GROUP_ACCESS")
-        
+
         if(length(name)==0) { ## create anonymous group
             id <- .Call("R_H5Gcreate_anon", self$id, group_create_pl$id, group_access_pl$id, PACKAGE = "hdf5r")$return_val
         }
@@ -335,7 +335,7 @@ commonFG <- list(
         }
         return(H5Group$new(id))
     },
-    create_dataset=function(name, robj=NULL, dtype=NULL, space=NULL, chunk_dims="auto", gzip_level=4, 
+    create_dataset=function(name, robj=NULL, dtype=NULL, space=NULL, chunk_dims="auto", gzip_level=4,
         link_create_pl=h5const$H5P_DEFAULT, dataset_create_pl=h5const$H5P_DEFAULT, dataset_access_pl=h5const$H5P_DEFAULT) {
         "This function is the main interface to create a new dataset. Its parameters allow for customization of the default"
         "behaviour, i.e. in order to get a specific datatype, a certain chunk size or dataset dimensionality."
@@ -423,13 +423,13 @@ commonFG <- list(
                 dataset_create_pl$set_deflate(gzip_level)
             }
         }
-        
+
         check_class(dtype, "H5T")
         check_class(space, "H5S")
         check_pl(link_create_pl, "H5P_LINK_CREATE")
         check_pl(dataset_create_pl, "H5P_DATASET_CREATE")
         check_pl(dataset_access_pl, "H5P_DATASET_ACCESS")
-        
+
         if(is.character(name) && length(name)==1) {
             id <- .Call("R_H5Dcreate2", self$id, name, dtype$id, space$id, link_create_pl$id, dataset_create_pl$id,
                         dataset_access_pl$id, PACKAGE="hdf5r")$return_val
@@ -485,7 +485,7 @@ commonFG <- list(
         if(herr < 0) {
             stop("An error occured creating the dataset")
         }
-        return(invisible(dtype))       
+        return(invisible(dtype))
 
     },
     ## functions around the link interface
@@ -519,7 +519,7 @@ commonFG <- list(
             stop(paste("Error creating soft link for path", target_path, "with link_name", link_name))
         }
         return(invisible(self))
-        
+
     },
     link_create_external=function(target_file_name, target_obj_name, link_name, link_create_pl=h5const$H5P_DEFAULT,
         link_access_pl=h5const$H5P_DEFAULT) {
@@ -535,7 +535,7 @@ commonFG <- list(
             stop(paste("Error creating external link for file", target_file_name, "with target object", target_obj_name, " and link_name", link_name))
         }
         return(invisible(self))
-               
+
     },
     link_exists=function(name, link_access_pl=h5const$H5P_DEFAULT) {
         "This function implements the HDF5-API function H5Lexists."
@@ -564,7 +564,7 @@ commonFG <- list(
             stop("Error copying object")
         }
         return(invisible(self))
-        
+
     },
     link_move_to=function(dst_loc, dst_name, src_name, link_create_pl=h5const$H5P_DEFAULT, link_access_pl=h5const$H5P_DEFAULT) {
         "This function implements the HDF5-API function H5Lmove."
@@ -581,7 +581,7 @@ commonFG <- list(
             stop("Error copying object")
         }
         return(invisible(self))
-      
+
     },
     link_copy_from=function(src_loc, src_name, dst_name, link_create_pl=h5const$H5P_DEFAULT, link_access_pl=h5const$H5P_DEFAULT) {
         "This function implements the HDF5-API function H5Lcopy."
@@ -598,7 +598,7 @@ commonFG <- list(
             stop("Error copying object")
         }
         return(invisible(self))
-        
+
     },
     link_copy_to=function(dst_loc, dst_name, src_name, link_create_pl=h5const$H5P_DEFAULT, link_access_pl=h5const$H5P_DEFAULT) {
         "This function implements the HDF5-API function H5Lcopy."
@@ -615,12 +615,12 @@ commonFG <- list(
             stop("Error copying object")
         }
         return(invisible(self))
-      
+
     },
     link_delete=function(name, link_access_pl=h5const$H5P_DEFAULT) {
         "This function implements the HDF5-API function H5Ldelete."
         "Please see the documentation at \\url{https://www.hdfgroup.org/HDF5/doc/RM/RM_H5L.html#Link-Delete} for details."
-        
+
         check_pl(link_access_pl, "H5P_LINK_ACCESS")
 
         herr <- .Call("R_H5Ldelete", self$id, name, link_access_pl$id, PACKAGE="hdf5r")$return_val
@@ -628,7 +628,7 @@ commonFG <- list(
             stop(paste("Error deleting link", name))
         }
         return(invisible(self))
-        
+
     },
     link_delete_by_idx=function(n, group_name=".", index_field=h5const$H5_INDEX_NAME, order=h5const$H5_ITER_NATIVE,
         link_access_pl=h5const$H5P_DEFAULT) {
@@ -646,7 +646,7 @@ commonFG <- list(
             stop(paste("Error deleting link number", n, "in group", group_name))
         }
         return(invisible(self))
-       
+
     },
     link_info=function(name, link_access_pl=h5const$H5P_DEFAULT) {
         "This function implements the HDF5-API function H5Lget_info."
@@ -771,7 +771,7 @@ commonFG <- list(
             stop("Problem getting name of link by index")
         }
         return(res$name)
-        
+
     },
     mount=function(name, child) {
         "This function implements the HDF5-API function H5Fmount."
@@ -806,7 +806,7 @@ commonFG <- list(
             stop("Error mounting file onto group")
         }
         return(self)
-    }    
+    }
     )
 
 
@@ -862,10 +862,10 @@ commonFGDT <- list(
         if(self$attr_exists(attr_name)) {
             stop("Can't create attribute; already exists")
         }
-        
+
         attr_create_pl <- h5const$H5P_DEFAULT
         attr_access_pl <- h5const$H5P_DEFAULT
-        
+
         ## adapt dtype, space as necessary
         if(is.null(robj) && (is.null(dtype) || is.null(space))) {
             stop("If a sample robj is not provided, both dtype and space have to be given")
@@ -876,7 +876,7 @@ commonFGDT <- list(
         if(is.null(space)) {
             space <- guess_space(x=robj, dtype=dtype, chunked=FALSE)
         }
-        
+
         id <- .Call("R_H5Acreate2", self$id, attr_name, dtype$id, space$id,
                      attr_create_pl$id, attr_access_pl$id, PACKAGE="hdf5r")$return_val
 
@@ -918,7 +918,7 @@ commonFGDT <- list(
         }
         attr_create_pl <- h5const$H5P_DEFAULT
         attr_access_pl <- h5const$H5P_DEFAULT
-        
+
         if(is.null(robj) && (is.null(dtype) || is.null(space))) {
             stop("If a sample robj is not provided, both dtype and space have to be given")
         }
@@ -978,7 +978,7 @@ commonFGDT <- list(
             stop("Problem creating new attribute")
         }
         return(H5A$new(id=id))
-        
+
     },
     attr_exists_by_name=function(attr_name, obj_name, link_access_pl=h5const$H5P_DEFAULT) {
         "This function implements the HDF5-API function H5Aexists_by_name."
@@ -1092,7 +1092,7 @@ commonFGDT <- list(
             stop("Problem deleting attribute by index")
         }
         return(invisible(self))
-        
+
     },
     attr_info_by_name=function(attr_name, obj_name, link_access_pl=h5const$H5P_DEFAULT) {
         "This function implements the HDF5-API function H5Aget_info_by_name."
@@ -1165,7 +1165,7 @@ commonFGDT <- list(
             stop("Error returning name of object")
         }
         return(res$name)
-    }    
+    }
     )
 
 
@@ -1176,7 +1176,7 @@ commonFGT <- list(
         "This function implements the HDF5-API function H5Rcreate. If \\code{space=NULL} then a \\code{H5R_OBJECT} reference"
         "is created, otherwise a \\code{H5R_DATASET_REGION} reference"
         "Please see the documentation at \\url{https://www.hdfgroup.org/HDF5/doc/RM/RM_H5R.html#Reference-Create} for details."
-        
+
         if(is.null(space)) {
             ref_type <- h5const$H5R_OBJECT
             space_id <- -1
@@ -1213,5 +1213,5 @@ commonFGDTA <- list(
             return(invisible(self))
         }
     }
-    
+
     )

--- a/R/R6Classes_H5File.R
+++ b/R/R6Classes_H5File.R
@@ -34,15 +34,15 @@
 H5File.open <-  function(name, mode=c("a", "r", "r+", "w", "w-", "x"), file_create_pl=h5const$H5P_DEFAULT, file_access_pl=h5const$H5P_DEFAULT) {
     check_pl(file_create_pl, "H5P_FILE_CREATE")
     check_pl(file_access_pl, "H5P_FILE_ACCESS")
-    
+
     stopifnot(is.character(name))
     stopifnot(length(name) == 1)
 
     mode <- match.arg(mode)
     mode.save <- mode
-    
+
     filename <- normalizePath(name, mustWork=FALSE)
-    
+
     ## now do the appropriate thing depending on the mode
     if(mode=="a") { # read/write if exists, create otherwise
         if(file.exists(filename)) {
@@ -85,7 +85,7 @@ H5File.open <-  function(name, mode=c("a", "r", "r+", "w", "w-", "x"), file_crea
 ##' @param name The name of the file to check; doesn't check for existence
 ##' @return Logical, TRUE if file is of type HDF5
 ##' @author Holger Hoefling
-##' @export 
+##' @export
 is_hdf5 <- function(name) {
     res <- .Call("R_H5Fis_hdf5", name, PACKAGE = "hdf5r")
     if(res < 0) {
@@ -101,7 +101,7 @@ is_hdf5 <- function(name) {
 #' \code{\link{H5RefClass-class}}. #'
 #' @docType class
 #' @importFrom R6 R6Class
-#' @return Object of class \code{\link{H5File}}. 
+#' @return Object of class \code{\link{H5File}}.
 #' @export
 #' @author Holger Hoefling
 #' @seealso H5Class_overview
@@ -118,7 +118,7 @@ H5File <- R6Class("H5File",
                           "existing file for reading, \\code{r+} opens an existing file for read/write. \\code{w} creates a file, truncating any"
                           "existing ones and \\code{w-}/\\code{x} are synonyms, creating a file and failing if it already exists."
 
-                      
+
                           if (is.null(id)) {
                              if (!is.null(filename)) {
                                id <- H5File.open(filename, mode, file_create_pl, file_access_pl)
@@ -185,7 +185,7 @@ H5File <- R6Class("H5File",
                       close_all=function(close_self=TRUE) {
                           "Closes the file, flushes it and also closes all open objects that are still open in it. This is the recommended way of"
                           "closing any file. If not all objects in a file are closed, the file remains open and cannot be re-opened the regular way."
-                          
+
                           ## first trigger the garbage collection, so that lost, but not yet collected objects are closed
                           gc()
                           obj_ids <- self$get_obj_ids()
@@ -202,8 +202,24 @@ H5File <- R6Class("H5File",
                               rm_obj(self$id)
                           }
                           return(invisible(self))
-                      } 
-                      ),                  
+                      }
+                      ## close=function(all=TRUE) {
+                      ##     "Closes an object and calls the appropriate HDF5 function for the type of object"
+                      ##     "@param all Closes all open objects of the file"
+                      ##     if(self$is_valid) {
+                      ##         if(all) {
+                      ##             self$close_all(close_self=TRUE)
+                      ##         }
+                      ##         else {
+                      ##             id <- private$pid$id
+                      ##             private$closeFun(id)
+                      ##             decr_count(id)
+                      ##         }
+                      ##         private$pid <- NA
+                      ##     }
+                      ##     return(invisible(self))
+                      ## }
+                      ),
                   private=list(
                       closeFun=function(id) {
                           if(!is.na(id) && is.loaded("R_H5Fclose", PACKAGE="hdf5r")) {
@@ -225,7 +241,7 @@ R6_set_list_of_items(H5File, "public", commonFGDTA, overwrite=TRUE)
 
 
 
-    
+
 ##' Closes any HDF5 id using the appropriate library function
 ##'
 ##' Internal function to help with management of open ids. It is used to close
@@ -257,7 +273,7 @@ H5_close_any <- function(id) {
                            H5I_GENPROP_CLS=.Call("R_H5Pclose_class", id, PACKAGE="hdf5r"),
                            H5I_GENPROP_LST=.Call("R_H5Pclose", id, PACKAGE="hdf5r"),
                            stop("Unknown type; can't close"))
-        
+
             if(herr < 0) {
                 stop(paste("Error closing id", id, "of type", type))
             }
@@ -267,4 +283,4 @@ H5_close_any <- function(id) {
 }
 
 
-    
+

--- a/R/h5wrapper.R
+++ b/R/h5wrapper.R
@@ -1,12 +1,12 @@
 #' h5 wrapper functions
-#' 
+#'
 #' Wrapper functions to provide h5 compatible interface.
 #' @param object H5RefClass; H5 Reference Class to be used
 #' @param name character; Group/Filename to be created
 #' @param path character; Path named to be used for iteration.
 #' @param recursive logical; Specify if object should be traversed recursively.
 #' @param ... Additional Parameters passed to \code{file$create_group}, \code{file$create_dataset}
-#' 
+#'
 #' @rdname h5-wrapper
 #' @export
 h5file <- H5File$new
@@ -42,7 +42,14 @@ readDataSet <- function(object) object$read()
 
 #' @rdname h5-wrapper
 #' @export
-h5close <- function(object) object$close()
+h5close <- function(object) {
+    if(inherits(object, "H5File")) {
+        object$close_all()
+    }
+    else {
+        object$close()
+    }
+}
 
 #' @rdname h5-wrapper
 #' @export
@@ -114,11 +121,11 @@ extendDataSet <- function(object, dims) {
   if(!all(dims >= ddset)) {
     stop("Number of extendible dimensions must be greater or equal than DataSet dimensions.")
   }
-  
+
   if(!all(dims <= object$maxdims)) {
     stop("Number of extendible dimensions exceeds maximum dimensions of DataSet.")
   }
-  
+
   object$set_extent(dims = dims)
   invisible(object)
 }
@@ -130,10 +137,10 @@ rbind.H5D <- function(x, mat) {
   endx <- x$dims[1] + nrow(mat)
 
   if(x$dims[2] != ncol(mat)) {
-    stop(sprintf("Data to append does not match dataset dimensions (%d != %d).", 
+    stop(sprintf("Data to append does not match dataset dimensions (%d != %d).",
                  x$dims[2], ncol(mat)))
   }
-  
+
   x[startx:endx, 1:x$dims[2]] <- mat
   invisible(x)
 }
@@ -143,12 +150,12 @@ rbind.H5D <- function(x, mat) {
 cbind.H5D <- function(x, mat) {
   starty <- x$dims[2] + 1
   endy <- x$dims[2] + ncol(mat)
-  
+
   if(x$dims[1] != nrow(mat)) {
-    stop(sprintf("Data to append does not match dataset dimensions (%d != %d).", 
+    stop(sprintf("Data to append does not match dataset dimensions (%d != %d).",
                  x$dims[1], nrow(mat)))
   }
-  
+
   x[1:x$dims[1], starty:endy] <- mat
   invisible(x)
 }
@@ -159,9 +166,9 @@ c.H5D <- function(x, ...) {
   vec <- do.call(c, list(...))
   start <- x$dims + 1
   end <- x$dims + length(vec)
-  
+
   if(length(x$dims) != length(GetDimensions(vec))) {
-    stop(sprintf("Data to append does not match dataset dimensions (%d != %d).", 
+    stop(sprintf("Data to append does not match dataset dimensions (%d != %d).",
                  length(x$dims), length(GetDimensions(vec))))
   }
   x[start:end] <- vec

--- a/R/high_level_UI.R
+++ b/R/high_level_UI.R
@@ -36,7 +36,7 @@
 ##' The items are then accessed, again similar to a list, using \code{[[}.
 ##' @title Get the names of the items in the group or at the \code{/} root of the file
 ##' @param x An object of class \code{\link{H5File}} or \code{\link{H5Group}}
-##' @return A character vector with the names of the items in the group/file. 
+##' @return A character vector with the names of the items in the group/file.
 ##' @author Holger Hoefling
 ##' @export
 names.H5Group <- function(x) {
@@ -61,13 +61,13 @@ names.H5File <- names.H5Group
 ##' HDF5-File or group \code{x}.
 ##'
 ##' One can also assign objects under a not yet existing name. For Either a  \code{\link{H5Group-class}} or \code{\link{H5D-class}},
-##' a hard link is created. If it is a datatype, \code{\link{H5T-class}}, this is committed under the chosen name \code{name}. 
+##' a hard link is created. If it is a datatype, \code{\link{H5T-class}}, this is committed under the chosen name \code{name}.
 ##' @title Retrieve object from a group of file
 ##' @param x An object of class \code{\link{H5File}} or \code{\link{H5Group}}
 ##' @param name Name of the object to retrieve. Has to be a character vector of length one. No integer values allowed/
 ##' @param ... Currently ignored
-##' @param link_access_pl An object of class \code{\link{H5P_LINK_ACCESS-class}}. 
-##' @param dataset_access_pl An object of class \code{\link{H5P_DATASET_ACCESS-class}}. 
+##' @param link_access_pl An object of class \code{\link{H5P_LINK_ACCESS-class}}.
+##' @param dataset_access_pl An object of class \code{\link{H5P_DATASET_ACCESS-class}}.
 ##' @param type_access_pl Currently always \code{h5const$H5P_DEFAULT}
 ##' @param value What to assign. Has to be one of \code{\link{H5Group-class}},  \code{\link{H5D-class}} or  \code{\link{H5T-class}}
 ##' @return A \code{\link{H5Group-class}},  \code{\link{H5D-class}} or  \code{\link{H5T-class}}, depending on the object saved in the group under
@@ -108,7 +108,7 @@ names.H5File <- names.H5Group
                 return(invisible(x))
             }
         }
-        
+
         stop("Cannot assign - already exists. Please use the 'link_delete' to delete the object before assigning a new one")
     }
     if(inherits(value, "H5Group")) {
@@ -137,10 +137,10 @@ names.H5File <- names.H5Group
 ##' Interface for HDF5 attributes
 ##'
 ##' Implements high-level functions that allows interactions with HDF5-attributes in a way very similar to regular R-object attributes
-##' in R are handled. 
+##' in R are handled.
 ##' @title Interface for HDF5 attributes
 ##' @param x The object to which to attach the attribute to or retrieve it from. Can be one of \code{\link{H5Group-class}},  \code{\link{H5D-class}},
-##' \code{\link{H5T-class}} or  \code{\link{H5File-class}} 
+##' \code{\link{H5T-class}} or  \code{\link{H5File-class}}
 ##' @param which The name of the attribute to assign it to
 ##' @param value The value to assign to the attribute.
 ##' @return For \code{h5attributes}, a named list with the content of the attributes read out. FOr \code{h5attr_names},
@@ -217,7 +217,7 @@ h5attr <- function(x, which) {
 ##' @param op Operation to perform on the \code{\link{H5S-class}}. Look into the HDF5 online help
 ##' \\url{https://www.hdfgroup.org/HDF5/doc/RM/RM_H5S.html#Dataspace-SelectElements} and
 ##' \\url{https://www.hdfgroup.org/HDF5/doc/RM/RM_H5S.html#Dataspace-SelectHyperslab}
-##' @param dataset_xfer_pl An object of class \code{\link{H5P_DATASET_XFER-class}}. 
+##' @param dataset_xfer_pl An object of class \code{\link{H5P_DATASET_XFER-class}}.
 ##' @param flags Some flags governing edge cases of conversion from HDF5 to R. This is related to how integers are being treated and
 ##' the issue of R not being able to natively represent 64bit integers and not at all being able to represent unsigned 64bit integers
 ##' (even using add-on packages). The constants governing this are part of \code{\link{h5const}}. The relevant ones start with the term
@@ -400,12 +400,12 @@ args_regularity_evaluation <- function(args, ds_dims, envir, post_read=TRUE) {
     if(length(args) != length(ds_dims)) {
         stop("Number of arguments not equal to number of dimensions: ", length(args), " vs. ", length(ds_dims))
     }
-    
+
     ## create the skeleton for the regularity report
     ## has columns: start, count, stride, block
     hyperslab <- matrix(rep(NA, length(args) * 4), ncol=4)
     colnames(hyperslab) <- c("start", "count", "stride", "block")
-    
+
     is_hyperslab <- rep(FALSE, length(args))
     needs_reshuffle <- is_hyperslab
     args_in <- args
@@ -414,7 +414,7 @@ args_regularity_evaluation <- function(args, ds_dims, envir, post_read=TRUE) {
     result_dims_post_shuffle <- numeric(length(args))
     max_dims <- result_dims_pre_shuffle
     reshuffle <- args_point
-    
+
     for(i in seq_along(args)) {
         cur_arg <- args[[i]]
         if(length(args[[i]]) == 1 && args[[i]]==quote(expr=)) {
@@ -428,7 +428,7 @@ args_regularity_evaluation <- function(args, ds_dims, envir, post_read=TRUE) {
             res_hyper <- c(NA, NA, NA, NA)
         }
         ## res_hyper contains the information if the argument can be interpreted as a hyperslab
-        
+
         if(!any(is.na(res_hyper))) { ## is a hyperslab made from a function
             is_hyperslab[i] <- TRUE
             hyperslab[i,] <- res_hyper
@@ -468,7 +468,7 @@ args_regularity_evaluation <- function(args, ds_dims, envir, post_read=TRUE) {
                         cur_arg <- seq_len(ds_dims[[i]])[cur_arg]
                     }
                     else if(!all(cur_arg > 0)) {
-                        stop("In index ", i, " not all subscripts are either positive or negative") 
+                        stop("In index ", i, " not all subscripts are either positive or negative")
                     }
                     ## then check if it can be written as a hyperslab
                     cur_arg_diff_unique <- unique(diff(cur_arg))
@@ -479,7 +479,7 @@ args_regularity_evaluation <- function(args, ds_dims, envir, post_read=TRUE) {
                         result_dims_post_shuffle[i] <- length(cur_arg)
                         if(length(cur_arg_diff_unique) == 1) {
                             is_hyperslab[i] <- TRUE
-                            
+
                             if(cur_arg_diff_unique == 1) {
                                 hyperslab[i, ] <- c(cur_arg[[1]], 1, 1, length(cur_arg))
                             }
@@ -518,8 +518,8 @@ args_regularity_evaluation <- function(args, ds_dims, envir, post_read=TRUE) {
                         max_dims[i] <- sort_arg[length(sort_arg)]
                         if(length(sort_arg_diff_unique) == 1) {
                             is_hyperslab[i] <- TRUE
-                            
-                            if(cur_arg_diff_unique == 1) {
+
+                            if(sort_arg_diff_unique == 1) {
                                 hyperslab[i, ] <- c(sort_arg[[1]], 1, 1, length(sort_arg))
                             }
                             else {
@@ -567,7 +567,7 @@ hyperslab_to_points <- function(hyperslab) {
         res <- rep(seq_len(hyperslab[[4]]), times=hyperslab[[2]])
         ## now add it the stride component
         res <- res + rep((seq_len(hyperslab[[2]]) - 1) * hyperslab[[3]], each=hyperslab[[4]])
-        res <- res + hyperslab[[1]] - 1       
+        res <- res + hyperslab[[1]] - 1
     }
     return(res)
 }
@@ -624,7 +624,7 @@ regularity_eval_to_selection <- function(reg_eval_res) {
                 args_point[[i]] <- hyperslab_to_points(reg_eval_res$hyperslab[i,])
             }
         }
-        
+
         sel <- expand_point_grid(args_point)
     }
     return(structure(.Data=sel, class=sel_type))
@@ -687,7 +687,7 @@ match.call.withDef <- function(definition, call) {
 
 ##' Reshuffle the input as needed - see \code{args_regularity_evaluation}
 ##'
-##' When necessary, this function performs the reshuffle as defined by \code{args_regularity_evaluation}. 
+##' When necessary, this function performs the reshuffle as defined by \code{args_regularity_evaluation}.
 ##' @title Reshuffle the input as needed - see \code{args_regularity_evaluation}
 ##' @param x The array to reshuffle
 ##' @param reg_eval_res The result of the regularity evaluation
@@ -709,7 +709,7 @@ do_reshuffle <- function (x, reg_eval_res) {
     }
     else {
         reorder_params <- rep(list(quote(expr=)), length(reg_eval_res$reshuffle))
-        
+
         reorder_params[reg_eval_res$needs_reshuffle] <- reg_eval_res$reshuffle[reg_eval_res$needs_reshuffle]
     }
     res <- do.call("[", c(list(x), reorder_params))

--- a/inst/download_libwin.sh
+++ b/inst/download_libwin.sh
@@ -5,7 +5,7 @@
 echo "  checking hdf5 headers and libraries"
 allok=yes
 
-LIBWIN="$(echo ${LIB_HDF5}/lib${R_ARCH} | sed 's/\\/\//g')"
+LIBWIN="$(echo ${LIB_HDF5}/lib/${R_ARCH} | sed 's/\\/\//g')"
 INC_HDF5=""
 
 if [ ! -e ${LIBWIN}/libhdf5_cpp.a ]; then

--- a/tests/testthat/test-zzz-DataSet.R
+++ b/tests/testthat/test-zzz-DataSet.R
@@ -2,33 +2,33 @@ context("h5-DataSet-createDataset")
 
 fname <- tempfile(fileext=".h5")
 
-test_that("DataSet-createDataset",{	
-	if(file.exists(fname)) file.remove(fname)
-	file <- h5file(fname, "a")
-  
+test_that("DataSet-createDataset",{
+    if(file.exists(fname)) file.remove(fname)
+    file <- h5file(fname, "a")
+
   f <- function() dset1 <- createDataSet(file, "testmat_n")
   expect_that(f(), throws_error("If a sample robj is not provided, both dtype and space have to be given"))
-  
+
   h5close(file)
   expect_that(file.remove(fname), is_true())
-})  
+})
 
-test_that("DataSet-createDataset-chunksize",{	
+test_that("DataSet-createDataset-chunksize",{
   if(file.exists(fname)) file.remove(fname)
   file <- h5file(fname, "a")
-  
+
   f <- function() dset1 <- createDataSet(file, "testmat_n", 1:10, chunk_dims = "test")
   expect_that(f(), throws_error("In RToH5_INTEGER can't convert type of object passed"))
-  
+
   dset_c9 <- createDataSet(file, "test_chunk_9", 1:10, chunk_dims = 9)
   h5close(dset_c9)
-  
+
   dset_c1 <- createDataSet(file, "test_chunk_1", 1:10, chunk_dims = 1)
   h5close(dset_c1)
-  
+
   f <- function() dset_c0 <- createDataSet(file, "test_chunk_0", 1:10, chunk_dims = 0)
   expect_that(f(), throws_error("all chunk dimensions must be positive"))
-  
+
   # TODO (mario): Create dataset without chunking?
   # ds_nochunk <- createDataSet(file, "dset", 1:3, chunk_dims = NA)
   # expect_that(ds_nochunk@chunksize, is_identical_to(NA_real_))
@@ -43,106 +43,106 @@ test_that("DataSet-createDataset-chunksize",{
   # expect_that(ds_chunk@compression , is_identical_to("H5Z_FILTER_DEFLATE"))
   # expect_that(ds_chunk@datatype, is_identical_to("i"))
   # h5close(ds_chunk)
-  # h5close(file)
-  # expect_that(file.remove(fname), is_true())
-})  
+  h5close(file)
+  expect_that(file.remove(fname), is_true())
+})
 
-test_that("DataSet-createDataset-maxdimensions",{	
+test_that("DataSet-createDataset-maxdimensions",{
   if(file.exists(fname)) file.remove(fname)
   file <- h5file(fname, "a")
-  
+
   # TODO(mario): H5S$new(maxdims = "test") should immediately throw error
   dspace <- H5S$new(maxdims = "test")
   #f <- function() dset1 <- createDataSet(file, "testmat_n", 1:10, chunk_dims = "test", space = dspace)
   #expect_that(f(), throws_error("Parameter maxdimensions must be of type integer"))
-  
+
   f <- function() dspace2 <- H5S$new(dims = c(10), maxdims = c(Inf, Inf))
   expect_that(f(), throws_error("maxdims, if it is not NULL, has to be of the same length as dims"))
-  
+
   f <- function() dspace2 <- H5S$new(dims = c(10), maxdims = c(9))
   expect_that(f(), throws_error("maxdims is smaller than dims"))
-  
+
   dspace2 <- H5S$new(dims = c(10), maxdims = c(10))
   dset_md_10 <- createDataSet(file, "test_md_10", 1:10, space = dspace2)
   h5close(dset_md_10)
- 
+
   testmat <- matrix(rep(1:10, 10), nrow = 10)
-  
+
   f <- function() dspace2 <- H5S$new(dims = c(10, 10), maxdims = c(9, 10))
   expect_that(f(), throws_error("maxdims is smaller than dims"))
-  
+
   dspace2 <- H5S$new(dims = c(10, 10), maxdims = c(10, 10))
   dset_md_10_10 <- createDataSet(file, "test_md_10_10", testmat, space = dspace2)
   h5close(dset_md_10_10)
-  
+
   h5close(file)
   expect_that(file.remove(fname), is_true())
-})  
+})
 
-test_that("DataSet-createDataset-compression",{	
+test_that("DataSet-createDataset-compression",{
   if(file.exists(fname)) file.remove(fname)
   file <- h5file(fname, "a")
-  
+
   f <- function() dset_cp_type <- createDataSet(file, "cp_type_n", 1:10, gzip = "test")
   expect_that(f(), throws_error("gzip_level has to be between 0 and 9"))
-  
+
   f <- function() dset_cp_-1 <- createDataSet(file, "cp_-1", 1:10, gzip = -1)
   expect_that(f(), throws_error("gzip_level has to be between 0 and 9"))
-  
+
   f <- function() dset_cp_10 <- createDataSet(file, "cp_10", 1:10, gzip = 10)
   expect_that(f(), throws_error("gzip_level has to be between 0 and 9"))
-  
+
   for(i in 0:9) {
     dset <- createDataSet(file, sprintf("cp_%d", i), 1:10, gzip = i)
     h5close(dset)
   }
-  
+
   h5close(file)
   expect_that(file.remove(fname), is_true())
-})  
+})
 
-test_that("DataSet-list-dataset",{	
+test_that("DataSet-list-dataset",{
   if(file.exists(fname)) file.remove(fname)
   file <- h5file(fname, "a")
-  
+
   f <- function() list.datasets(file, path = "path doesn't exist")
   expect_that(f(), throws_error("An object with name path doesn't exist does not exist in this group"))
-  
+
   expect_that(list.datasets(file), is_identical_to(character(0)))
-  
+
   group <- createGroup(file, "testgroup")
   group[["testset"]] <- 1:3
   expect_that(list.datasets(file), is_identical_to(c("testgroup/testset")))
 
   # TODO: Fix Bug implicit group extract/create
-  #expect_that(list.datasets(file["/testgroup"], recursive = FALSE), 
+  #expect_that(list.datasets(file["/testgroup"], recursive = FALSE),
   #    is_identical_to(c("/testgroup/testset")))
   testgroup <- file[["/testgroup"]]
-  expect_that(list.datasets(testgroup, recursive = FALSE),          
+  expect_that(list.datasets(testgroup, recursive = FALSE),
       is_identical_to(c("testset")))
   h5close(testgroup)
   expect_that(list.datasets(file), is_identical_to(c("testgroup/testset")))
 
   g1 <- createGroup(file, "testgroup/testgroup1")
   file[["testgroup/testgroup1/testset1"]] <- 1:3
-  
+
   g2 <- createGroup(file, "testgroup/testgroup2")
   file[["testgroup/testgroup2/testset2"]] <- 1:3
-  
+
   g3 <- createGroup(file, "testgroup3")
   createGroup(file, "testgroup3/testgroup3")
   file[["testgroup3/testgroup3/testset3"]] <- 1:3
 
   group <- createGroup(file, "testgroupN")
   h5close(group)
-  
+
   ex <- c("testgroup/testgroup1/testset1", "testgroup/testgroup2/testset2",
           "testgroup/testset", "testgroup3/testgroup3/testset3")
   expect_that(list.datasets(file), is_identical_to(ex))
-  
+
   #ex <- c("testset1", "testset2", "testset", "testset3")
   #expect_that(list.datasets(file), is_identical_to(ex))
-  
+
   ex <- c("testgroup1/testset1", "testgroup2/testset2",
           "testset")
   testgroup <- file[["testgroup"]]
@@ -150,54 +150,54 @@ test_that("DataSet-list-dataset",{
   h5close(testgroup)
   h5close(file)
   expect_that(file.remove(fname), is_true())
-})  
+})
 
-test_that("DataSet-list-dataset",{	
+test_that("DataSet-list-dataset",{
   if(file.exists(fname)) file.remove(fname)
   file <- h5file(fname, "a")
   abc <- createGroup(file, "ABC")
-  
+
   file[["ABC/1A"]] <- 1:3
   file[["ABC/1B"]] <- 1:3
   file[["ABC/1C"]] <- 1:3
   file[["ABC/1D"]] <- 1:3
   file[["ABC/1E"]] <- 1:3
   file[["ABC/1F"]] <- 1:3
-  
+
   ex <- c("ABC/1A", "ABC/1B", "ABC/1C", "ABC/1D", "ABC/1E", "ABC/1F")
   expect_that(list.datasets(file), is_identical_to(ex))
 
   expect_that(list.datasets(file, recursive = FALSE), is_identical_to(character(0)))
-  
+
   h5close(file)
   expect_that(file.remove(fname), is_true())
 
 })
 
-test_that("DataSet-list-dataset-link",{	
+test_that("DataSet-list-dataset-link",{
   fname <- system.file("test-h5link.h5", package = "hdf5r", mustWork = TRUE)
   file <- h5file(fname, "r")
-  
+
   # TODO(mario): check why H5T_STD_I64LE is not mapped to 64bit integer
   expect_that(file[["hardlink/test2"]][], is_identical_to(1:3))
   expect_that(file[["softlink/test3/test"]][], is_identical_to(1:3))
-  
+
   expect_that(list.datasets(file[["softlink"]]), is_identical_to(character(0)))
-  
+
   # TODO(mario): Implement follow.link
   # exp1 <- c("softlink/test3/subgroup/test-sub", "softlink/test3/test")
   # expect_that(list.datasets(file[["softlink"]], follow.link = TRUE), is_identical_to(exp1))
-  
+
   exp2 <- c("hardlink/test2", "testgroup/subgroup/test-sub", "testgroup/test")
   expect_that(list.datasets(file), is_identical_to(exp2))
-  
+
   #exp3 <- "softlink/test3/test"
   expect_that(list.datasets(file[["softlink/test3"]], recursive = FALSE), is_identical_to("test"))
 
   h5close(file)
-})  
+})
 
-test_that("DataSet-Bug-F32-Issue10",{	
+test_that("DataSet-Bug-F32-Issue10",{
   fname <- system.file("test-f32.h5", package = "hdf5r", mustWork = TRUE)
   file <- h5file(fname, "r")
   expect_that(file[["floats"]][], is_identical_to(c(1, 2, 3)))

--- a/tests/testthat/test-zzz-H5File-Subset.R
+++ b/tests/testthat/test-zzz-H5File-Subset.R
@@ -4,55 +4,55 @@ fname <- tempfile(fileext=".h5")
 test_that("H5File-Subset-Group",{
   if(file.exists(fname)) file.remove(fname)
   file <- h5file(fname, "a")
-  
+
   f <- function() file[[c("1", "2", "3")]]
   expect_that(f(), throws_error("An object with name 1 does not exist in this group"))
 
   group3 <- createGroup(file, "/testgroup3")
   expect_that(group3, is_a("H5Group"))
   expect_that(group3$get_obj_name(), is_identical_to("/testgroup3"))
-  
+
   groupnested <- createGroup(group3, "test")
   expect_that(groupnested, is_a("H5Group"))
   expect_that(groupnested$get_obj_name(), is_identical_to("/testgroup3/test"))
   h5close(groupnested)
   h5close(group3)
-  
+
   group3 <- file[["/testgroup3"]]
   grouprelative <- group3[["test"]]
   expect_that(grouprelative, is_a("H5Group"))
   expect_that(grouprelative$get_obj_name(), is_identical_to("/testgroup3/test"))
   h5close(grouprelative)
   h5close(group3)
-  
-  # TODO(mario): recursive group creation 
+
+  # TODO(mario): recursive group creation
   # group5 <- file["/test1/test2/test3/test4/test5"]
-  
-  
+
+
   # expect_that(group5, is_a("H5Group"))
   # expect_that(group5@location, is_identical_to("/test1/test2/test3/test4/test5"))
   # h5close(group5)
-  # h5close(file)
-  # expect_that(file.remove(fname), is_true())
+  h5close(file)
+  expect_that(file.remove(fname), is_true())
 })
 
 test_that("H5File-Subset-DataSet",{
   if(file.exists(fname)) file.remove(fname)
   file <- h5file(fname, "a")
-  
+
   # TODO(mario): Implicit, recursive group creation?
   # group5 <- file["/test1/test2/test3/test4/test5"]
-  
+
   g1 <- createGroup(file, "test/test1/test2/test3")
-  g1[["dset1"]] <- 1:10              
+  g1[["dset1"]] <- 1:10
   g1[["dset2"]] <- matrix(1:9, nrow = 3)
   g1[["dset3"]] <- array(1:6, dim = c(1, 2, 3))
   file[["dset4"]] <- matrix(1:10, nrow = 5)
-  
+
   # TODO: should work without h5close()
   h5close(g1)
   h5close(file)
-  
+
   file <- h5file(fname, "r")
   dset <- file[["test/test1/test2/test3/dset1"]]
   expect_that(readDataSet(dset), is_identical_to(1:10))
@@ -61,32 +61,32 @@ test_that("H5File-Subset-DataSet",{
   dset <- file[["test/test1/test2/test3/dset2"]]
   expect_that(readDataSet(dset), is_identical_to(matrix(1:9, nrow = 3)))
   h5close(dset)
-  
+
   # TODO(mario): Does array retrieval work?
   # dset <- file[["test/test1/test2/test3/dset3"]]
   # expect_that(readDataSet(dset), is_identical_to(array(1:6, dim = c(1, 2, 3))))
   # h5close(dset)
-  
+
   dset <- file[["dset4"]]
   expect_that(readDataSet(dset), is_identical_to(matrix(1:10, nrow = 5)))
   h5close(dset)
-  
+
   # check subsets
   # TODO: should work without h5close()
   dset <- file[["test/test1/test2/test3/dset1"]]
   expect_that(dset[1:5], is_identical_to(1:5))
   h5close(dset)
-  
+
   dset <- file[["test/test1/test2/test3/dset2"]]
   expect_that(dset[1:2,], is_identical_to(matrix(1:9, nrow = 3)[1:2,]))
   h5close(dset)
-  
+
   # TODO(mario): Does array retrieval work?
   # dset <- file[["test/test1/test2/test3/dset3"]]
-  # expect_that(dset[1,1:2,3], 
+  # expect_that(dset[1,1:2,3],
   #     is_identical_to(array(1:6, dim = c(1, 2, 3))[1,1:2,3,drop = FALSE]))
   # h5close(dset)
-  
+
   # set subsets
   # TODO: include test cases
   h5close(file)

--- a/tests/testthat/test-zzz-H5Group.R
+++ b/tests/testthat/test-zzz-H5Group.R
@@ -4,15 +4,15 @@ fname <- tempfile(fileext=".h5")
 test_that("H5Group-param",{
   if(file.exists(fname)) file.remove(fname)
   file <- h5file(fname)
-  
+
   group1 <- createGroup(file, "//testgroup")
   expect_that(group1, is_a("H5Group"))
   h5close(group1)
-  
+
   group2 <- createGroup(file, "testgroup2//")
   expect_that(group2, is_a("H5Group"))
   h5close(group2)
-  
+
   # Does not need to throw an error
   # f <- function() grouproot <- createGroup(file, "/")
   # expect_that(f(), throws_error("H5Gcreate failed"))
@@ -29,15 +29,15 @@ test_that("H5Group-param",{
 test_that("H5Group-createGroup",{
   if(file.exists(fname)) file.remove(fname)
   file <- h5file(fname)
-  
+
   # Not Fail for nested (non-existent) group name
   # f <- function() group1 <- createGroup(file, "/testgroup/test")
   # expect_that(f(), throws_error("H5Gcreate failed"))
-  
+
   group3 <- createGroup(file, "/testgroup3")
   expect_that(group3, is_a("H5Group"))
   expect_that(group3$get_obj_name(), is_identical_to("/testgroup3"))
-  
+
   groupnested <- createGroup(group3, "/test")
   expect_that(groupnested, is_a("H5Group"))
   expect_that(groupnested$get_obj_name(), is_identical_to("/testgroup3/test"))
@@ -52,24 +52,24 @@ test_that("H5Group-openLocation",{
   # Fail for nested (non-existent) group name
   f <- function() group1 <- openLocation(file, "/testgroup/test")
   expect_that(f(), throws_error("component not found"))
-  
+
   group3 <- openLocation(file, "/testgroup3")
   expect_that(group3, is_a("H5Group"))
   expect_that(group3$get_obj_name(), is_identical_to("/testgroup3"))
-  
+
   groupnested <- openLocation(group3, "test")
   expect_that(groupnested, is_a("H5Group"))
   expect_that(groupnested$get_obj_name(), is_identical_to("/testgroup3/test"))
   h5close(groupnested)
   h5close(group3)
-  
+
   group3 <- openLocation(file, "/testgroup3")
   grouprelative <- openLocation(group3, "test")
   expect_that(grouprelative, is_a("H5Group"))
   expect_that(grouprelative$get_obj_name(), is_identical_to("/testgroup3/test"))
   # TODO: should absolute path be displayed?
   # eg. expect_that(grouprelative@name, is_identical_to("/testgroup3/test"))
-  
+
   h5close(grouprelative)
   h5close(group3)
   h5close(file)
@@ -79,10 +79,10 @@ test_that("H5Group-existsGroup",{
   expect_that(file.exists(fname), is_true())
   file <- h5file(fname, "r")
   # Fail for nested (non-existent) group name
-  expect_that(existsGroup(file, "/testgroup/test"), is_false())     
+  expect_that(existsGroup(file, "/testgroup/test"), is_false())
   expect_that(existsGroup(file, "/testgroup3"), is_true())
   expect_that(existsGroup(file, "/testgroup3/test"), is_true())
-  
+
   group3 <- openLocation(file, "/testgroup3")
   expect_that(existsGroup(group3, "test"), is_true())
   h5close(group3)
@@ -90,25 +90,25 @@ test_that("H5Group-existsGroup",{
   expect_that(file.remove(fname), is_true())
 })
 
-test_that("CommonFG-list-groups",{	
+test_that("CommonFG-list-groups",{
   if(file.exists(fname)) file.remove(fname)
   file <- h5file(fname, "a")
-  
+
   # TODO(mario): Adjust error message if object[[path]] is nonexistent
   f <- function() list.groups(file, path = "a/be/bu")
   expect_that(f(), throws_error("component not found"))
   expect_that(list.groups(file), is_identical_to(character(0)))
-  
+
   g1 <- createGroup(file, "testgroup")
   g1[["testset"]] <- 1:3
   expect_that(list.groups(file), is_identical_to(c("testgroup")))
   expect_that(list.groups(file, recursive = FALSE), is_identical_to(c("testgroup")))
   expect_that(list.groups(file), is_identical_to(c("testgroup")))
-  
+
   g11 <- createGroup(g1, "testgroup1")
   g12 <- createGroup(g1, "testgroup2")
   g13 <- createGroup(g1, "testgroup3")
-  
+
   g11[["testset1"]] <- 1:3
   g12[["testset2"]] <- 1:3
   g13[["testset3"]] <- 1:3
@@ -116,63 +116,63 @@ test_that("CommonFG-list-groups",{
 
   group <- createGroup(file, "testgroupN")
   h5close(group)
-  
+
   ex <- c("testgroup", "testgroup/testgroup1", "testgroup/testgroup2",
  	"testgroup/testgroup3", "testgroupN")
   expect_that(list.groups(file), is_identical_to(ex))
-  
+
   ex <- c("testgroup", "testgroup1", "testgroup2", "testgroup3", "testgroupN")
   expect_that(basename(list.groups(file)), is_identical_to(ex))
-  
+
   ex <- c("testgroup", "testgroupN")
   expect_that(list.groups(file, recursive = FALSE), is_identical_to(ex))
 
   ex <- c("testgroup1", "testgroup2", "testgroup3")
   testgroup <- file[["testgroup"]]
   #expect_that(list.groups(file["testgroup"], full.names = TRUE), is_identical_to(ex))
-  expect_that(list.groups(testgroup), is_identical_to(ex))    
+  expect_that(list.groups(testgroup), is_identical_to(ex))
   h5close(testgroup)
 
   h5close(file)
   expect_that(file.remove(fname), is_true())
-})  
+})
 
-test_that("CommonFG-unlink",{	
+test_that("CommonFG-unlink",{
   if(file.exists(fname)) file.remove(fname)
-  
+
   file <- h5file(fname)
   g1 <- createGroup(file, "testgroup")
   g2 <- createGroup(file, "testgroup2")
   g1[["testset"]] <- 1:3
   g1[["testset2"]] <- 1:3
   g2[["testset"]] <- 1:3
-  
+
   h5close(file)
 
-  file <- h5file(fname, "r")
-  
+  file <- h5file(fname, "r+")
+
   # unlink group
   ex <- c("testgroup/testset",  "testgroup/testset2", "testgroup2/testset")
-  expect_that(list.datasets(file, recursive = TRUE), 
+  expect_that(list.datasets(file, recursive = TRUE),
       is_identical_to(ex))
-  
+
   # unlink dataset
   expect_that(h5unlink(file, "testgroup"), is_true())
   expect_that(h5unlink(file, "testgroup2/testset"), is_true())
-  expect_that(list.datasets(file, recursive = TRUE), 
+  expect_that(list.datasets(file, recursive = TRUE),
       is_identical_to(character(0)))
-  expect_that(list.groups(file, recursive = TRUE), 
+  expect_that(list.groups(file, recursive = TRUE),
       is_identical_to("testgroup2"))
-  
+
   # remove last group
   expect_that(h5unlink(file, "testgroup2"), is_true())
-  expect_that(list.groups(file, recursive = TRUE), 
+  expect_that(list.groups(file, recursive = TRUE),
       is_identical_to(character(0)))
-  
+
   # remove non-existing
   # expect_that(h5unlink(file, "testgroup2"), is_false())
   # expect_that(h5unlink(file, "testgroup2/testset"), is_false())
-  
+
   # add data sets again
   g1 <- createGroup(file, "testgroup")
   g2 <- createGroup(file, "testgroup2")
@@ -180,9 +180,9 @@ test_that("CommonFG-unlink",{
   g1[["testset2"]] <- 5:6
   g2[["testset"]] <- 5:6
   h5close(file)
-  
+
   file <- h5file(fname, "a")
-  
+
   # TODO(mario): check why this still leaves an open file handle
   expect_that(file[["testgroup/testset"]][], is_identical_to(5:6))
   expect_that(file[["testgroup/testset2"]][], is_identical_to(5:6))
@@ -197,14 +197,14 @@ test_that("CommonFG-unlink",{
   testset3 <- file[["testgroup2/testset"]]
   expect_that(testset3[], is_identical_to(5:6))
   h5close(testset3)
-  
+
   # remove multiple datasets, 1 missing
   # TODO: check if file is read-only mode
-  res <- h5unlink(file, c("testgroup/testset", "testgroup/testset2", 
+  res <- h5unlink(file, c("testgroup/testset", "testgroup/testset2",
           "testgroup2/testset", "testgroup2/missing"))
   names(res) <- NULL
   expect_that(res, is_identical_to(c(TRUE, TRUE, TRUE, FALSE)))
   h5close(file)
-  
+
   expect_that(file.remove(fname), is_true())
-})  
+})


### PR DESCRIPTION
- h5close now calls for H5File object $close_all() instead of $close, in
order to also close all objects in the file that are still open
- Fixed an issue in test-zzz-H5Group where a file was openen read-only
when trying to delete links
- Fixed an error in the high-level dataset code
- Fixed tests zzz-Dataset and zzz-H5File-Subset, where the testfile was
not closed and deleted