### PR TITLE
set default for max.attributes in print, addresses #89

### DIFF
--- a/R/R6Classes_H5D.R
+++ b/R/R6Classes_H5D.R
@@ -617,7 +617,7 @@ H5D <- R6Class("H5D",
                        ref_obj$ref <- res$ref
                        return(ref_obj)
                    },
-                   print=function(..., max.attributes){
+                   print=function(..., max.attributes = 10){
                           "Prints information for the dataset"
                           "@param ... ignored"
                           "@param max.attributes Maximum number of attribute names to print"


### PR DESCRIPTION
Sets the default for the maximum number of attributes to print to 10. This is now consistent with the behavior for [H5File](https://github.com/hhoeflin/hdf5r/blob/master/R/R6Classes_H5File.R#L292) and [H5Group](https://github.com/hhoeflin/hdf5r/blob/master/R/R6Classes_H5Group.R#L46)