### PR TITLE
Use specific symbols/structs instead of macros

### DIFF
--- a/src/H5Error.c
+++ b/src/H5Error.c
@@ -89,7 +89,7 @@ herr_t _errorCollector( hid_t estack_id, void * stream) {
     client_data.pos = strlen(client_data.err_msg);
     ssize_t initial_pos = client_data.pos;
 
-    herr_t eee = H5Ewalk(estack_id, H5E_WALK_DOWNWARD, &custom_print_cb, &client_data);
+    herr_t eee = H5Ewalk2(estack_id, H5E_WALK_DOWNWARD, &custom_print_cb, &client_data);
     if(eee < 0) {
       client_data.err_msg = "Error walking the error stack!";
       client_data.pos = strlen(client_data.err_msg);
@@ -120,15 +120,15 @@ herr_t _errorCollector( hid_t estack_id, void * stream) {
 
 
 SEXP R_H5error() {
-  H5E_auto_t err_func;
+  H5E_auto2_t err_func;
   void *err_func_data;
   herr_t err;
-  err = H5Eget_auto (H5E_DEFAULT, &err_func, &err_func_data);
+  err = H5Eget_auto2 (H5E_DEFAULT, &err_func, &err_func_data);
   if(err < 0) {
     error("Error retrieving current error handler");
   }
-  H5E_auto_t myfct = &_errorCollector;
-  err = H5Eset_auto (H5E_DEFAULT, myfct, err_func_data);
+  H5E_auto2_t myfct = &_errorCollector;
+  err = H5Eset_auto2 (H5E_DEFAULT, myfct, err_func_data);
   if(err < 0) {
     error("Error setting custom error handler");
   }

--- a/src/convert.c
+++ b/src/convert.c
@@ -2121,7 +2121,7 @@ SEXP get_array_dim(hid_t dtype_id) {
 
   int total_num_dims = XLENGTH(dim);
   hsize_t cur_array_dim[array_rank];
-  H5Tget_array_dims(dtype_id, cur_array_dim);
+  H5Tget_array_dims2(dtype_id, cur_array_dim);
 
   for(int i=0; i < array_rank; ++i) {
     INTEGER(dim)[total_num_dims - 1 - i] = cur_array_dim[i];


### PR DESCRIPTION
Given that hdf5r minimum hdf5 version is 1.8.13, it is safe to use the
1.8+-only versions of the various functions/structs that were previously
addressed via macros. This includes H5Ewalk, H5E_auto_t,
H5E{get,set}_auto and H5Tget_array_dims.

This is usually not a problem when compiling against your everyday hdf5
library, but it becomes an issue when the target hdf5 library was
compiled with --with-default-api-version=v16. This causes the macros to
map by default to the *1 version of the functions/structs, breaking the
code.

An alternative solution was to add the necessary macro definitions in
the Makevars.in file to force the usage of the newer API, but
compatibility with 1.6 is not really required to begin with.

This fixes #104.