### PR TITLE
Automatically build against hdf5 from rwinlib (fixes #128)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -28,3 +28,5 @@ wercker.yml
 ^docs$
 ^_pkgdown\.yml$
 ^cran-comments\.md$
+windows
+

--- a/Makefile
+++ b/Makefile
@@ -20,16 +20,6 @@ CHECKPATH := $(PKG_NAME).Rcheck
 CHECKLOG := `cat $(CHECKPATH)/00check.log`
 CURRENT_DIR := $(shell pwd)
 
-# Makevars used for CRAN release
-HDF5_VERSION_USE=1_8_14
-WINC=$${LIB_HDF5}/include
-WLIB=$${LIB_HDF5}/lib$${R_ARCH}
-HDF5R_CPPFLAGS=
-DEFINE_H5FREE_MEMORY=0
-HDF5R_LIBS=-L${WLIB} -lhdf5 -lhdf5_hl -lz -lm
-HDF5R_CFLAGS=-I${WINC}/hdf5 -I${WINC}/hdf5_hl -I${WINC}/cmakeconf -I${HDF5_VERSION_USE} -I.
-# Makevars end
-
 .PHONY: all build check manual install clean compileAttributes roxygen\
 	build-cran check-cran doc 
 
@@ -45,18 +35,6 @@ $(PKG_NAME)_$(PKG_VERSION).tar.gz: $(PKG_FILES)
 build-cran:
 	@make clean
 	@make roxygen
-	# Generate src/Makevars.win
-	sed -e 's#@HDF5_VERSION_USE@#${HDF5_VERSION_USE}#g' -e 's#@HDF5R_CFLAGS@#${HDF5R_CFLAGS}#g'  \
--e  's#@HDF5R_CPPFLAGS@#${HDF5R_CPPFLAGS}#g' -e  's#@HDF5R_LIBS@#${HDF5R_LIBS}#g' \
--e  's#@DEFINE_H5FREE_MEMORY@#${DEFINE_H5FREE_MEMORY}#g' \
-src/Makevars.in > src/Makevars.win
-	# Swap configure.win
-	@cp configure.win configure.win.temp; cat /dev/null >| configure.win
-	R CMD build --resave-data .
-	# Unswap configure.win
-	@cp configure.win.temp configure.win; rm configure.win.temp
-	# Remove src/Makevars.win
-	rm src/Makevars.win
 
 roxygen: $(R_FILES)
 	$(R) 'devtools::load_all(".", reset=TRUE, recompile = FALSE, export_all=FALSE)';

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,6 @@ install:
 # Adapt as necessary starting from here
 
 build_script:
-  - Rscript -e "source('https://bioconductor.org/biocLite.R')"
   - travis-tool.sh install_deps
   - echo %CD%
   - ls
@@ -28,7 +27,6 @@ environment:
   WARNINGS_ARE_ERRORS: 1
   _R_CHECK_FORCE_SUGGESTS_: FALSE
   R_ARCH: x64
-  HDF5_VERSION_USE: 1_8_14
 
 artifacts:
   - path: '*.Rcheck\**\*.log'

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,0 +1,26 @@
+WRAP = 1_10_3
+VERSION = 1.10.5
+LIB_HDF5 = ../windows/hdf5-$(VERSION)
+
+PKG_LIBS = -L${LIB_HDF5}/lib${R_ARCH} -lhdf5 -lhdf5_hl -lz -lm 
+PKG_CFLAGS=-I${LIB_HDF5}/include -I$(WRAP) -I. -D__USE_MINGW_ANSI_STDIO
+
+.PHONY: clean all winlibs
+
+all: clean winlibs $(SHLIB)
+
+OBJECTS = $(WRAP)/const_export.o $(WRAP)/datatype_export.o $(WRAP)/Wrapper_auto_H5A.o \
+	$(WRAP)/Wrapper_auto_H5.o $(WRAP)/Wrapper_auto_H5D.o $(WRAP)/Wrapper_auto_H5DS.o $(WRAP)/Wrapper_auto_H5E.o \
+	$(WRAP)/Wrapper_auto_H5F.o $(WRAP)/Wrapper_auto_H5G.o $(WRAP)/Wrapper_auto_H5I.o $(WRAP)/Wrapper_auto_H5IM.o \
+	$(WRAP)/Wrapper_auto_H5L.o $(WRAP)/Wrapper_auto_H5LT.o $(WRAP)/Wrapper_auto_H5O.o $(WRAP)/Wrapper_auto_H5P.o \
+	$(WRAP)/Wrapper_auto_H5R.o $(WRAP)/Wrapper_auto_H5S.o $(WRAP)/Wrapper_auto_H5TB.o $(WRAP)/Wrapper_auto_H5T.o \
+	$(WRAP)/Wrapper_auto_H5Z.o $(WRAP)/Wrapper_auto_H5FDcore.o $(WRAP)/Wrapper_auto_H5FDfamily.o \
+	$(WRAP)/Wrapper_auto_H5FDlog.o $(WRAP)/Wrapper_auto_H5FDsec2.o $(WRAP)/Wrapper_auto_H5FDstdio.o \
+	convert.o hdf5r_init.o H5Error.o H5ls.o Wrapper_manual_H5T.o
+
+winlibs:
+	@echo "Linking to HDF5 $(RWINLIB)"
+	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" "../tools/winlibs.R" $(VERSION)
+
+clean:
+	rm -f $(SHLIB) $(OBJECTS)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,8 +1,8 @@
-WRAP = 1_10_3
-VERSION = 1.10.5
+WRAP = 1_8_16
+VERSION = 1.8.16
 LIB_HDF5 = ../windows/hdf5-$(VERSION)
 
-PKG_LIBS = -L${LIB_HDF5}/lib${R_ARCH} -lhdf5 -lhdf5_hl -lz -lm 
+PKG_LIBS = -L${LIB_HDF5}/lib-4.9.3${R_ARCH} -lhdf5 -lhdf5_hl -lz -lm 
 PKG_CFLAGS=-I${LIB_HDF5}/include -I$(WRAP) -I. -D__USE_MINGW_ANSI_STDIO
 
 .PHONY: clean all winlibs

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,13 +1,10 @@
 WRAP = 1_8_16
 VERSION = 1.8.16
-LIB_HDF5 = ../windows/hdf5-$(VERSION)
+RWINLIB = ../windows/hdf5-$(VERSION)
+PKG_LIBS = -L${RWINLIB}/lib-4.9.3${R_ARCH} -lhdf5 -lhdf5_hl -lz -lm 
+PKG_CPPFLAGS = -I${RWINLIB}/include -I$(WRAP) -I. -D__USE_MINGW_ANSI_STDIO
 
-PKG_LIBS = -L${LIB_HDF5}/lib-4.9.3${R_ARCH} -lhdf5 -lhdf5_hl -lz -lm 
-PKG_CFLAGS=-I${LIB_HDF5}/include -I$(WRAP) -I. -D__USE_MINGW_ANSI_STDIO
-
-.PHONY: clean all winlibs
-
-all: clean winlibs $(SHLIB)
+all: winlibs
 
 OBJECTS = $(WRAP)/const_export.o $(WRAP)/datatype_export.o $(WRAP)/Wrapper_auto_H5A.o \
 	$(WRAP)/Wrapper_auto_H5.o $(WRAP)/Wrapper_auto_H5D.o $(WRAP)/Wrapper_auto_H5DS.o $(WRAP)/Wrapper_auto_H5E.o \
@@ -22,5 +19,5 @@ winlibs:
 	@echo "Linking to HDF5 $(RWINLIB)"
 	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" "../tools/winlibs.R" $(VERSION)
 
-clean:
-	rm -f $(SHLIB) $(OBJECTS)
+.PHONY: all winlibs
+

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -1,0 +1,9 @@
+# Build against rwinlib build of hdf5
+VERSION <- commandArgs(TRUE)
+if(!file.exists(sprintf("../windows/hdf5-%s/include/hdf5.h", VERSION))){
+  download.file(sprintf("https://github.com/rwinlib/hdf5/archive/v%s.zip", VERSION),
+                "lib.zip", quiet = TRUE)
+  dir.create("../windows", showWarnings = FALSE)
+  unzip("lib.zip", exdir = "../windows")
+  unlink("lib.zip")
+}


### PR DESCRIPTION
Automatically downoad libhdf5 from [rwinlib](https://github.com/rwinlib/hdf5) at build time.

This makes it possible for any user, build server, or CI to install the source package on Windows. You never have to worry about which version of hdf5 is installed on the server.

Also cleaned up your Makevars.win and appveyor.