### PR TITLE
grep case insensitive (fixes #165)

### DIFF
--- a/configure
+++ b/configure
@@ -4385,7 +4385,7 @@ $as_echo "no" >&6; }
     as_fn_error $? "${GREP} does not support option -o" "$LINENO" 5
   fi
 
-  LIBS=`${H5CC} -show | ${GREP} -o "\-L[^[:space:]]\+" | tr "\n" " "`
+  LIBS=`${H5CC} -show | ${GREP} -o " \-[lL][^[:space:]]\+" | tr "\n" " "`
 
 
     HDF5R_LIBS="${LIBS} -L. -lhdf5_hl -lhdf5 -lz -lm"

--- a/configure.ac
+++ b/configure.ac
@@ -105,7 +105,7 @@ if test -z "${LIBS}"; then
     AC_MSG_ERROR([${GREP} does not support option -o])
   fi
   [
-  LIBS=`${H5CC} -show | ${GREP} -o "\-L[^[:space:]]\+" | tr "\n" " "` 
+  LIBS=`${H5CC} -show | ${GREP} -o " \-[lL][^[:space:]]\+" | tr "\n" " "` 
   ]
   
   dnl Fix for newer Debian versions


### PR DESCRIPTION
This takes both the `-L` and `-l` flags from the `h5cc` output, such that we link to the proper libraries, including szip.
I verified this works on MacOS with a static library (i.e. like CRAN)