### PR TITLE
Windows: optimize makevars.win

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,0 +1,2 @@
+CRT=-ucrt
+include Makevars.win

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,19 +1,26 @@
 WRAP = 1_8_16
 VERSION = 1.8.16
 RWINLIB = ../windows/hdf5-$(VERSION)
-PKG_LIBS = -L${RWINLIB}/lib-4.9.3${R_ARCH} -lhdf5 -lhdf5_hl -lz -lm 
+PKG_LIBS = -L. -lwrapper -L${RWINLIB}/lib${R_ARCH}${CRT} -lhdf5 -lhdf5_hl -lz -lm
 PKG_CPPFLAGS = -I${RWINLIB}/include -I$(WRAP) -I. -D__USE_MINGW_ANSI_STDIO
 
 all: winlibs
 
-OBJECTS = $(WRAP)/const_export.o $(WRAP)/datatype_export.o $(WRAP)/Wrapper_auto_H5A.o \
+STATLIB=libwrapper.a
+
+WRAPPER = $(WRAP)/const_export.o $(WRAP)/datatype_export.o $(WRAP)/Wrapper_auto_H5A.o \
 	$(WRAP)/Wrapper_auto_H5.o $(WRAP)/Wrapper_auto_H5D.o $(WRAP)/Wrapper_auto_H5DS.o $(WRAP)/Wrapper_auto_H5E.o \
 	$(WRAP)/Wrapper_auto_H5F.o $(WRAP)/Wrapper_auto_H5G.o $(WRAP)/Wrapper_auto_H5I.o $(WRAP)/Wrapper_auto_H5IM.o \
 	$(WRAP)/Wrapper_auto_H5L.o $(WRAP)/Wrapper_auto_H5LT.o $(WRAP)/Wrapper_auto_H5O.o $(WRAP)/Wrapper_auto_H5P.o \
 	$(WRAP)/Wrapper_auto_H5R.o $(WRAP)/Wrapper_auto_H5S.o $(WRAP)/Wrapper_auto_H5TB.o $(WRAP)/Wrapper_auto_H5T.o \
 	$(WRAP)/Wrapper_auto_H5Z.o $(WRAP)/Wrapper_auto_H5FDcore.o $(WRAP)/Wrapper_auto_H5FDfamily.o \
-	$(WRAP)/Wrapper_auto_H5FDlog.o $(WRAP)/Wrapper_auto_H5FDsec2.o $(WRAP)/Wrapper_auto_H5FDstdio.o \
-	convert.o hdf5r_init.o H5Error.o H5ls.o Wrapper_manual_H5T.o
+	$(WRAP)/Wrapper_auto_H5FDlog.o $(WRAP)/Wrapper_auto_H5FDsec2.o $(WRAP)/Wrapper_auto_H5FDstdio.o
+
+$(SHLIB): $(STATLIB)
+
+$(STATLIB): $(WRAPPER)
+
+$(WRAPPER): winlibs
 
 winlibs:
 	@echo "Linking to HDF5 $(RWINLIB)"


### PR DESCRIPTION
Some small tweaks for your Windows setup that to optimize the build and support the new ucrt tooclhains.