### PR TITLE
add fix for issue with empty attributes

### DIFF
--- a/src/1_10_0/Wrapper_auto_H5A.c
+++ b/src/1_10_0/Wrapper_auto_H5A.c
@@ -617,7 +617,7 @@ SEXP R_H5Aread(SEXP R_attr_id, SEXP R_type_id, SEXP R_buf, SEXP _dupl_buf){
   hid_t attr_id = SEXP_to_longlong(R_attr_id, 0);
   hid_t type_id = SEXP_to_longlong(R_type_id, 0);
   void* buf;
-  if(XLENGTH(R_buf) == 0) {
+  if(TYPEOF(R_buf) == NILSXP) {
     buf = NULL;
   }
   else {
@@ -693,7 +693,7 @@ SEXP R_H5Awrite(SEXP R_attr_id, SEXP R_type_id, SEXP R_buf){
   hid_t attr_id = SEXP_to_longlong(R_attr_id, 0);
   hid_t type_id = SEXP_to_longlong(R_type_id, 0);
   const void* buf;
-  if(XLENGTH(R_buf) == 0) {
+  if(TYPEOF(R_buf) == NILSXP) {
     buf = NULL;
   }
   else {

--- a/src/1_10_0/Wrapper_auto_H5D.c
+++ b/src/1_10_0/Wrapper_auto_H5D.c
@@ -545,7 +545,7 @@ SEXP R_H5Dvlen_reclaim(SEXP R_type_id, SEXP R_space_id, SEXP R_plist_id, SEXP R_
   hid_t space_id = SEXP_to_longlong(R_space_id, 0);
   hid_t plist_id = SEXP_to_longlong(R_plist_id, 0);
   void* buf;
-  if(XLENGTH(R_buf) == 0) {
+  if(TYPEOF(R_buf) == NILSXP) {
     buf = NULL;
   }
   else {

--- a/src/1_10_2/Wrapper_auto_H5A.c
+++ b/src/1_10_2/Wrapper_auto_H5A.c
@@ -617,7 +617,7 @@ SEXP R_H5Aread(SEXP R_attr_id, SEXP R_type_id, SEXP R_buf, SEXP _dupl_buf){
   hid_t attr_id = SEXP_to_longlong(R_attr_id, 0);
   hid_t type_id = SEXP_to_longlong(R_type_id, 0);
   void* buf;
-  if(XLENGTH(R_buf) == 0) {
+  if(TYPEOF(R_buf) == NILSXP) {
     buf = NULL;
   }
   else {
@@ -693,7 +693,7 @@ SEXP R_H5Awrite(SEXP R_attr_id, SEXP R_type_id, SEXP R_buf){
   hid_t attr_id = SEXP_to_longlong(R_attr_id, 0);
   hid_t type_id = SEXP_to_longlong(R_type_id, 0);
   const void* buf;
-  if(XLENGTH(R_buf) == 0) {
+  if(TYPEOF(R_buf) == NILSXP) {
     buf = NULL;
   }
   else {

--- a/src/1_10_2/Wrapper_auto_H5D.c
+++ b/src/1_10_2/Wrapper_auto_H5D.c
@@ -592,7 +592,7 @@ SEXP R_H5Dvlen_reclaim(SEXP R_type_id, SEXP R_space_id, SEXP R_plist_id, SEXP R_
   hid_t space_id = SEXP_to_longlong(R_space_id, 0);
   hid_t plist_id = SEXP_to_longlong(R_plist_id, 0);
   void* buf;
-  if(XLENGTH(R_buf) == 0) {
+  if(TYPEOF(R_buf) == NILSXP) {
     buf = NULL;
   }
   else {

--- a/src/1_10_3/Wrapper_auto_H5A.c
+++ b/src/1_10_3/Wrapper_auto_H5A.c
@@ -617,7 +617,7 @@ SEXP R_H5Aread(SEXP R_attr_id, SEXP R_type_id, SEXP R_buf, SEXP _dupl_buf){
   hid_t attr_id = SEXP_to_longlong(R_attr_id, 0);
   hid_t type_id = SEXP_to_longlong(R_type_id, 0);
   void* buf;
-  if(XLENGTH(R_buf) == 0) {
+  if(TYPEOF(R_buf) == NILSXP) {
     buf = NULL;
   }
   else {
@@ -693,7 +693,7 @@ SEXP R_H5Awrite(SEXP R_attr_id, SEXP R_type_id, SEXP R_buf){
   hid_t attr_id = SEXP_to_longlong(R_attr_id, 0);
   hid_t type_id = SEXP_to_longlong(R_type_id, 0);
   const void* buf;
-  if(XLENGTH(R_buf) == 0) {
+  if(TYPEOF(R_buf) == NILSXP) {
     buf = NULL;
   }
   else {

--- a/src/1_10_3/Wrapper_auto_H5D.c
+++ b/src/1_10_3/Wrapper_auto_H5D.c
@@ -653,7 +653,7 @@ SEXP R_H5Dvlen_reclaim(SEXP R_type_id, SEXP R_space_id, SEXP R_plist_id, SEXP R_
   hid_t space_id = SEXP_to_longlong(R_space_id, 0);
   hid_t plist_id = SEXP_to_longlong(R_plist_id, 0);
   void* buf;
-  if(XLENGTH(R_buf) == 0) {
+  if(TYPEOF(R_buf) == NILSXP) {
     buf = NULL;
   }
   else {

--- a/src/1_12_0/Wrapper_auto_H5A.c
+++ b/src/1_12_0/Wrapper_auto_H5A.c
@@ -617,7 +617,7 @@ SEXP R_H5Aread(SEXP R_attr_id, SEXP R_type_id, SEXP R_buf, SEXP _dupl_buf){
   hid_t attr_id = SEXP_to_longlong(R_attr_id, 0);
   hid_t type_id = SEXP_to_longlong(R_type_id, 0);
   void* buf;
-  if(XLENGTH(R_buf) == 0) {
+  if(TYPEOF(R_buf) == NILSXP) {
     buf = NULL;
   }
   else {
@@ -693,7 +693,7 @@ SEXP R_H5Awrite(SEXP R_attr_id, SEXP R_type_id, SEXP R_buf){
   hid_t attr_id = SEXP_to_longlong(R_attr_id, 0);
   hid_t type_id = SEXP_to_longlong(R_type_id, 0);
   const void* buf;
-  if(XLENGTH(R_buf) == 0) {
+  if(TYPEOF(R_buf) == NILSXP) {
     buf = NULL;
   }
   else {

--- a/src/1_12_0/Wrapper_auto_H5D.c
+++ b/src/1_12_0/Wrapper_auto_H5D.c
@@ -859,7 +859,7 @@ SEXP R_H5Dvlen_reclaim(SEXP R_type_id, SEXP R_space_id, SEXP R_plist_id, SEXP R_
   hid_t space_id = SEXP_to_longlong(R_space_id, 0);
   hid_t plist_id = SEXP_to_longlong(R_plist_id, 0);
   void* buf;
-  if(XLENGTH(R_buf) == 0) {
+  if(TYPEOF(R_buf) == NILSXP) {
     buf = NULL;
   }
   else {

--- a/src/1_8_12/Wrapper_auto_H5A.c
+++ b/src/1_8_12/Wrapper_auto_H5A.c
@@ -617,7 +617,7 @@ SEXP R_H5Aread(SEXP R_attr_id, SEXP R_type_id, SEXP R_buf, SEXP _dupl_buf){
   hid_t attr_id = SEXP_to_longlong(R_attr_id, 0);
   hid_t type_id = SEXP_to_longlong(R_type_id, 0);
   void* buf;
-  if(XLENGTH(R_buf) == 0) {
+  if(TYPEOF(R_buf) == NILSXP) {
     buf = NULL;
   }
   else {
@@ -693,7 +693,7 @@ SEXP R_H5Awrite(SEXP R_attr_id, SEXP R_type_id, SEXP R_buf){
   hid_t attr_id = SEXP_to_longlong(R_attr_id, 0);
   hid_t type_id = SEXP_to_longlong(R_type_id, 0);
   const void* buf;
-  if(XLENGTH(R_buf) == 0) {
+  if(TYPEOF(R_buf) == NILSXP) {
     buf = NULL;
   }
   else {

--- a/src/1_8_12/Wrapper_auto_H5D.c
+++ b/src/1_8_12/Wrapper_auto_H5D.c
@@ -447,7 +447,7 @@ SEXP R_H5Dvlen_reclaim(SEXP R_type_id, SEXP R_space_id, SEXP R_plist_id, SEXP R_
   hid_t space_id = SEXP_to_longlong(R_space_id, 0);
   hid_t plist_id = SEXP_to_longlong(R_plist_id, 0);
   void* buf;
-  if(XLENGTH(R_buf) == 0) {
+  if(TYPEOF(R_buf) == NILSXP) {
     buf = NULL;
   }
   else {

--- a/src/1_8_14/Wrapper_auto_H5A.c
+++ b/src/1_8_14/Wrapper_auto_H5A.c
@@ -617,7 +617,7 @@ SEXP R_H5Aread(SEXP R_attr_id, SEXP R_type_id, SEXP R_buf, SEXP _dupl_buf){
   hid_t attr_id = SEXP_to_longlong(R_attr_id, 0);
   hid_t type_id = SEXP_to_longlong(R_type_id, 0);
   void* buf;
-  if(XLENGTH(R_buf) == 0) {
+  if(TYPEOF(R_buf) == NILSXP) {
     buf = NULL;
   }
   else {
@@ -693,7 +693,7 @@ SEXP R_H5Awrite(SEXP R_attr_id, SEXP R_type_id, SEXP R_buf){
   hid_t attr_id = SEXP_to_longlong(R_attr_id, 0);
   hid_t type_id = SEXP_to_longlong(R_type_id, 0);
   const void* buf;
-  if(XLENGTH(R_buf) == 0) {
+  if(TYPEOF(R_buf) == NILSXP) {
     buf = NULL;
   }
   else {

--- a/src/1_8_14/Wrapper_auto_H5D.c
+++ b/src/1_8_14/Wrapper_auto_H5D.c
@@ -447,7 +447,7 @@ SEXP R_H5Dvlen_reclaim(SEXP R_type_id, SEXP R_space_id, SEXP R_plist_id, SEXP R_
   hid_t space_id = SEXP_to_longlong(R_space_id, 0);
   hid_t plist_id = SEXP_to_longlong(R_plist_id, 0);
   void* buf;
-  if(XLENGTH(R_buf) == 0) {
+  if(TYPEOF(R_buf) == NILSXP) {
     buf = NULL;
   }
   else {

--- a/src/1_8_16/Wrapper_auto_H5A.c
+++ b/src/1_8_16/Wrapper_auto_H5A.c
@@ -617,7 +617,7 @@ SEXP R_H5Aread(SEXP R_attr_id, SEXP R_type_id, SEXP R_buf, SEXP _dupl_buf){
   hid_t attr_id = SEXP_to_longlong(R_attr_id, 0);
   hid_t type_id = SEXP_to_longlong(R_type_id, 0);
   void* buf;
-  if(XLENGTH(R_buf) == 0) {
+  if(TYPEOF(R_buf) == NILSXP) {
     buf = NULL;
   }
   else {
@@ -693,7 +693,7 @@ SEXP R_H5Awrite(SEXP R_attr_id, SEXP R_type_id, SEXP R_buf){
   hid_t attr_id = SEXP_to_longlong(R_attr_id, 0);
   hid_t type_id = SEXP_to_longlong(R_type_id, 0);
   const void* buf;
-  if(XLENGTH(R_buf) == 0) {
+  if(TYPEOF(R_buf) == NILSXP) {
     buf = NULL;
   }
   else {

--- a/src/1_8_16/Wrapper_auto_H5D.c
+++ b/src/1_8_16/Wrapper_auto_H5D.c
@@ -447,7 +447,7 @@ SEXP R_H5Dvlen_reclaim(SEXP R_type_id, SEXP R_space_id, SEXP R_plist_id, SEXP R_
   hid_t space_id = SEXP_to_longlong(R_space_id, 0);
   hid_t plist_id = SEXP_to_longlong(R_plist_id, 0);
   void* buf;
-  if(XLENGTH(R_buf) == 0) {
+  if(TYPEOF(R_buf) == NILSXP) {
     buf = NULL;
   }
   else {

--- a/tests/testthat/test-h5a.R
+++ b/tests/testthat/test-h5a.R
@@ -181,3 +181,75 @@ test_that("Creating attributes of different types", {
 
 
 
+test_that("Creating attributes of different types of length 0", {
+    test_file <- tempfile(fileext=".h5")
+    ## open a new one, truncate if it exists
+    file.h5 <- H5File$new(test_file, mode="w")
+
+    ## now create different types
+    ## integer, long integer, float, enum, compound, strings
+    ## create a dataset for each of them
+    dtype_int64 <- h5types$H5T_NATIVE_LLONG
+    dtype_int32 <- h5types$H5T_NATIVE_INT
+    dtype_float <- h5types$H5T_NATIVE_FLOAT
+    dtype_double <- h5types$H5T_NATIVE_DOUBLE
+
+    ## enums
+    enum_logical <- H5T_LOGICAL$new()
+    factor_levels <- paste("test", 1:10, sep="")
+    enum_factor <- H5T_ENUM$new(labels=factor_levels)
+
+    ## strings
+    dtype_string_variable_utf8 <- H5T_STRING$new()$set_size(Inf)$set_cset(h5const$H5T_CSET_UTF8)
+    dtype_string_short_utf8 <- H5T_STRING$new()$set_size(10)$set_cset(h5const$H5T_CSET_UTF8)
+
+    ## compound
+    dtype_cpd <- H5T_COMPOUND$new(dtypes=list(dtype_int32, dtype_int32), labels=c("a", "b"))
+
+
+    ## now create a simple dataspace for the new objects;
+    ## will be the same for all, single dimension of size 0
+    attrspace <- H5S$new(type="simple", dims=0, maxdims=0)
+
+    ## create named datasets for all these types
+    attr_int64 <- file.h5$create_attr(attr_name="int64", dtype=dtype_int64, space=attrspace)
+    attr_int32 <- file.h5$create_attr(attr_name="int32", dtype=dtype_int32, space=attrspace)
+    attr_float <- file.h5$create_attr(attr_name="float", dtype=dtype_float, space=attrspace)
+    attr_double <- file.h5$create_attr(attr_name="double", dtype=dtype_double, space=attrspace)
+    attr_logical <- file.h5$create_attr(attr_name="enum_logical", dtype=enum_logical, space=attrspace)
+    attr_factor <- file.h5$create_attr(attr_name="enum_factor", dtype=enum_factor, space=attrspace)
+    attr_string_short <- file.h5$create_attr(attr_name="string_short", dtype=dtype_string_short_utf8, space=attrspace)
+    attr_string_variable <- file.h5$create_attr(attr_name="string_variable", dtype=dtype_string_variable_utf8, space=attrspace)
+    attr_cpd <- file.h5$create_attr(attr_name="cpd", dtype=dtype_cpd, space=attrspace)
+
+        ## now write data into the dataset, and read it back out again
+    res_int32 <- read_write_roundtrip(attr_int32, integer(0))
+    expect_equal(res_int32$input, res_int32$output)
+
+    res_int64 <- read_write_roundtrip(attr_int64, integer(0))
+    expect_equal(res_int64$input, res_int64$output)
+
+    res_float <- read_write_roundtrip(attr_float, numeric(0))
+    expect_equal(res_float$input, res_float$output)
+
+    res_double <- read_write_roundtrip(attr_double, numeric(0))
+    expect_equal(res_double$input, res_double$output)
+
+    res_logical <- read_write_roundtrip(attr_logical, logical(0))
+    expect_equal(res_logical$input, res_logical$output)
+
+    res_factor <- read_write_roundtrip(attr_factor, factor(character(0), levels=paste("test", 1:10, sep="")))
+    expect_equal(res_factor$input, res_factor$output)
+
+    res_string_short <- read_write_roundtrip(attr_string_short, character(0))
+    expect_equal(substr(res_string_short$input, 1,10), res_string_short$output)
+
+    res_string_variable <- read_write_roundtrip(attr_string_variable, character(0))
+    expect_equal(res_string_variable$input, res_string_variable$output)
+
+    res_cpd <- read_write_roundtrip(attr_cpd, data.frame())
+    expect_equal(res_cpd$input, res_cpd$output)
+    
+    file.h5$close_all()
+    file.remove(test_file)
+})

--- a/tests/testthat/test-h5a.R
+++ b/tests/testthat/test-h5a.R
@@ -247,7 +247,7 @@ test_that("Creating attributes of different types of length 0", {
     res_string_variable <- read_write_roundtrip(attr_string_variable, character(0))
     expect_equal(res_string_variable$input, res_string_variable$output)
 
-    res_cpd <- read_write_roundtrip(attr_cpd, data.frame())
+    res_cpd <- read_write_roundtrip(attr_cpd, data.frame(a = numeric(0), b = numeric(0)))
     expect_equal(res_cpd$input, res_cpd$output)
     
     file.h5$close_all()


### PR DESCRIPTION
This PR adds a fix for the issue described in #208 and tested in #209.

I made changes to several instances `XLENGTH(R_buf) == 0` was being used to check `R_buf` should be cast to a void pointer.

```c
  if(XLENGTH(R_buf) == 0) {
    buf = NULL;
  }
  else {
    buf = (void *) VOIDPTR(R_buf);
  }
```

However, since the implementation of `VOIDPTR` is:

```c
void* VOIDPTR(SEXP x) {

  switch(TYPEOF(x)) {
  case REALSXP:
    return((void *) REAL(x));
  case INTSXP:
    return((void *) INTEGER(x));
  case LGLSXP:
    return((void *) LOGICAL(x));
  case CPLXSXP:
    return((void *) COMPLEX(x));
  case RAWSXP:
    return((void *) RAW(x));
  case STRSXP:
    return((void *) STRING_PTR(x));
  case VECSXP:
    return((void *) VECTOR_PTR(x));
  default:
    error("Type cannot be converted to voidptr\n");
  }
}
```

I figured it may perhaps make more sense to check whether `TYPEOF(R_buf) == NILSXP` instead. I replaced `XLENGTH(.) == 0` with `TYPEOF(R_buf) == NILSXP` in the places where the unit tests in #209 caused errors. Specifically:

--------

If I undo my changes in `R_H5Awrite()`, I get:

    Error (test-h5a.R:226:5): Creating attributes of different types of length 0
    Error in `h5attr$write(robj)`: HDF5-API Errors:
        error #000: ../../src/H5A.c in H5Awrite(): line 657: buf parameter can't be NULL
            class: HDF5
            major: Invalid arguments to routine
            minor: Bad value

This may be related to https://github.com/mojaveazure/seurat-disk/issues/15#issuecomment-1259973265

-------

If I undo my changes in `R_H5Aread()`, I get:

    Error (test-h5a.R:226:5): Creating attributes of different types of length 0
    Error in `h5attr$read()`: HDF5-API Errors:
        error #000: ../../src/H5A.c in H5Aread(): line 702: buf parameter can't be NULL
            class: HDF5
            major: Invalid arguments to routine
            minor: Bad value

-------

And if I undo my changes in `R_H5Dvlen_reclaim()`, I get:

    Error (test-h5a.R:247:5): Creating attributes of different types of length 0
    Error in `h5attr$read()`: HDF5-API Errors:
        error #000: ../../src/H5Ddeprec.c in H5Dvlen_reclaim(): line 323: invalid argument
            class: HDF5
            major: Invalid arguments to routine
            minor: Bad value

This may be related to #118, PMBio/MuDataSeurat#14 and JiekaiLab/scDIOR#7

------

@hhoeflin I'd appreciate your feedback on this :relaxed:
